### PR TITLE
fix(lib): possible 'length' undefined from link rel styleSheets

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function fixOutline(opts) {
         // Use existing sheet or create new one
         var sheet = sheets.length < 0
                   ? createStyleSheet()
-                  // filters out styleCheets who don't have cssRules
+                  // filters out styleSheets that don't have cssRules
                   : sheets[Object.keys(sheets).filter(function (val) {
                     return sheets[val].cssRules;
                   }).pop()];

--- a/index.js
+++ b/index.js
@@ -53,8 +53,12 @@ function fixOutline(opts) {
     function addFocusRule() {
         var sheets = document.styleSheets;
         // Use existing sheet or create new one
-        var sheet = sheets.length > 0 ? sheets[0] : createStyleSheet();
-
+        var sheet = sheets.length < 0
+                  ? createStyleSheet()
+                  // filters out styleCheets who don't have cssRules
+                  : sheets[Object.keys(sheets).filter(function (val) {
+                    return sheets[val].cssRules;
+                  }).pop()];
         // Disable element outline on focus if
         // user has _not_ used keyboard navigation
         var rule = 'body:not(.kb-nav-used) *:focus {' +


### PR DESCRIPTION
__Description__:
CLOSES #2

If as user defines `link rel="stylesheet"` before their `.css` asset it will throw since a `link` without an attached stylesheet does not have `cssRules`. For example linking a font asset as such, `<link href="https://fonts.googleapis.com/css?family=Asar" rel="stylesheet">`.
